### PR TITLE
Fixing "just now" test

### DIFF
--- a/test/spec.js
+++ b/test/spec.js
@@ -11,7 +11,7 @@ describe('ago', function() {
 
 	it('should return "just now" if under 1 minute', function() {
 		expect(ago(timestamp)).to.equal('just now');
-		expect(ago(new Date(timestamp + 10000))).to.equal('just now');
+		expect(ago(new Date(+timestamp + 10000))).to.equal('just now');
 	});
 
 	it('minute', function() {


### PR DESCRIPTION
The intention of the test is to create `Date` that is 10s after `timestamp`. Unfortunately, `timestamp + 10000` does not do that. This expression is a string concatenation. You should convert the `timestamp` to number to create the expected `Date`.