### PR TITLE
Support custom units

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,9 @@
-declare const _default: (date: Date, max?: string) => string;
+declare const _default: (date: Date, max?: string, units?: {
+    max: number;
+    value: number;
+    name: string;
+    past: string;
+    future: string;
+    plural: string;
+}[]) => string;
 export = _default;

--- a/index.js
+++ b/index.js
@@ -14,36 +14,31 @@ ago(yesterday); // 'yesterday'
 ago(hoursAgo); // '6 hours ago'
 
 */
-function format(diff, divisor, unit, past, future, isInTheFuture) {
+function format(diff, divisor, plural, past, future, isInTheFuture) {
     var val = Math.round(Math.abs(diff) / divisor);
     if (isInTheFuture)
-        return val <= 1 ? future : 'in ' + val + ' ' + unit + 's';
-    return val <= 1 ? past : val + ' ' + unit + 's ago';
+        return val <= 1 ? future : 'in ' + val + plural;
+    return val <= 1 ? past : val + plural + ' ago';
 }
-var units = [
-    { max: 2760000, value: 60000, name: 'minute', past: 'a minute ago', future: 'in a minute' },
-    { max: 72000000, value: 3600000, name: 'hour', past: 'an hour ago', future: 'in an hour' },
-    { max: 518400000, value: 86400000, name: 'day', past: 'yesterday', future: 'tomorrow' },
-    { max: 2419200000, value: 604800000, name: 'week', past: 'last week', future: 'in a week' },
-    { max: 28512000000, value: 2592000000, name: 'month', past: 'last month', future: 'in a month' } // max: 11 months
+var defaultUnits = [
+    { max: 2760000, value: 60000, name: 'minute', past: 'a minute ago', future: 'in a minute', plural: ' minutes' },
+    { max: 72000000, value: 3600000, name: 'hour', past: 'an hour ago', future: 'in an hour', plural: ' hours' },
+    { max: 518400000, value: 86400000, name: 'day', past: 'yesterday', future: 'tomorrow', plural: ' days' },
+    { max: 2419200000, value: 604800000, name: 'week', past: 'last week', future: 'in a week', plural: ' weeks' },
+    { max: 28512000000, value: 2592000000, name: 'month', past: 'last month', future: 'in a month', plural: ' months' },
+    { max: Infinity, value: 31536000000, name: 'year', past: 'last year', future: 'in a year', plural: ' years' },
 ];
-module.exports = function ago(date, max) {
+module.exports = function ago(date, max, units) {
+    if (units === void 0) { units = defaultUnits; }
     var diff = Date.now() - date.getTime();
     // less than a minute
     if (Math.abs(diff) < 60000)
         return 'just now';
     for (var i = 0; i < units.length; i++) {
         if (Math.abs(diff) < units[i].max || (max && units[i].name === max)) {
-            return format(diff, units[i].value, units[i].name, units[i].past, units[i].future, diff < 0);
+            return format(diff, units[i].value, units[i].plural, units[i].past, units[i].future, diff < 0);
         }
     }
-    // `year` is the final unit.
-    // same as:
-    //  {
-    //    max: Infinity,
-    //    value: 31536000000,
-    //    name: 'year',
-    //    past: 'last year'
-    //  }
-    return format(diff, 31536000000, 'year', 'last year', 'in a year', diff < 0);
+    var _a = units[units.length - 1], value = _a.value, name = _a.name, past = _a.past, future = _a.future;
+    return format(diff, value, name, past, future, diff < 0);
 };

--- a/index.ts
+++ b/index.ts
@@ -14,21 +14,22 @@ ago(hoursAgo); // '6 hours ago'
 
 */
 
-function format(diff: number, divisor: number, unit: string, past: string, future: string, isInTheFuture: boolean) {
+function format(diff: number, divisor: number, plural: string, past: string, future: string, isInTheFuture: boolean) {
   var val = Math.round(Math.abs(diff) / divisor);
-  if (isInTheFuture) return val <= 1 ? future : 'in ' + val + ' ' + unit + 's';
-  return val <= 1 ? past : val + ' ' + unit + 's ago';
+  if (isInTheFuture) return val <= 1 ? future : 'in ' + val + plural;
+  return val <= 1 ? past : val + plural + ' ago';
 }
 
-const units = [
-  { max: 2760000, value: 60000, name: 'minute', past: 'a minute ago', future: 'in a minute' }, // max: 46 minutes
-  { max: 72000000, value: 3600000, name: 'hour', past: 'an hour ago', future: 'in an hour' }, // max: 20 hours
-  { max: 518400000, value: 86400000, name: 'day', past: 'yesterday', future: 'tomorrow' }, // max: 6 days
-  { max: 2419200000, value: 604800000, name: 'week', past: 'last week', future: 'in a week' }, // max: 28 days
-  { max: 28512000000, value: 2592000000, name: 'month', past: 'last month', future: 'in a month' } // max: 11 months
+const defaultUnits = [
+  { max: 2760000, value: 60000, name: 'minute', past: 'a minute ago', future: 'in a minute', plural: ' minutes' }, // max: 46 minutes
+  { max: 72000000, value: 3600000, name: 'hour', past: 'an hour ago', future: 'in an hour', plural: ' hours' }, // max: 20 hours
+  { max: 518400000, value: 86400000, name: 'day', past: 'yesterday', future: 'tomorrow', plural: ' days' }, // max: 6 days
+  { max: 2419200000, value: 604800000, name: 'week', past: 'last week', future: 'in a week', plural: ' weeks' }, // max: 28 days
+  { max: 28512000000, value: 2592000000, name: 'month', past: 'last month', future: 'in a month', plural: ' months' }, // max: 11 months
+  { max: Infinity, value: 31536000000, name: 'year', past: 'last year', future: 'in a year', plural: ' years' },
 ];
 
-export = function ago(date: Date, max?: string): string {
+export = function ago(date: Date, max?: string, units = defaultUnits): string {
   const diff = Date.now() - date.getTime();
 
   // less than a minute
@@ -36,18 +37,10 @@ export = function ago(date: Date, max?: string): string {
 
   for (var i = 0; i < units.length; i++) {
     if (Math.abs(diff) < units[i].max || (max && units[i].name === max)) {
-      return format(diff, units[i].value, units[i].name, units[i].past, units[i].future, diff < 0);
+      return format(diff, units[i].value, units[i].plural, units[i].past, units[i].future, diff < 0);
     }
   }
 
-  // `year` is the final unit.
-  // same as:
-  //  {
-  //    max: Infinity,
-  //    value: 31536000000,
-  //    name: 'year',
-  //    past: 'last year'
-  //  }
-  return format(diff, 31536000000, 'year', 'last year', 'in a year', diff < 0);
-
+  const { value, name, past, future } = units[units.length - 1];
+  return format(diff, value, name, past, future, diff < 0);
 };

--- a/test/test.js
+++ b/test/test.js
@@ -228,3 +228,33 @@ test('boundaries future', (t) => {
   t.is(ago(years), 'in 2 years');
   t.is(ago(years2), 'in 15 years');
 });
+
+test('custom units', (t) => {
+  const shortUnits = [
+    { max: 2760000, value: 60000, name: 'minute', past: '1m ago', future: 'in 1m', plural: 'm' }, // max: 46 minutes
+    { max: 72000000, value: 3600000, name: 'hour', past: '1h ago', future: 'in 1h', plural: 'h' }, // max: 20 hours
+    { max: Infinity, value: 86400000, name: 'day', past: '1d ago', future: 'in 1d', plural: 'd' }, // max: Infinity
+  ];
+
+  // past
+  {
+    t.is(ago(new Date(timestamp.valueOf() - (60 * 1000)), 'day', shortUnits), '1m ago');
+    t.is(ago(new Date(timestamp.valueOf() - (1.8 * 60 * 1000)), 'day', shortUnits), '2m ago');
+    t.is(ago(new Date(timestamp.valueOf() - (14.7 * 60 * 1000)), 'day', shortUnits), '15m ago');
+    t.is(ago(new Date(timestamp.valueOf() - (1.8 * 60 * 60 * 1000)), 'day', shortUnits), '2h ago');
+    t.is(ago(new Date(timestamp.valueOf() - (18.8 * 60 * 60 * 1000)), 'day', shortUnits), '19h ago');
+    t.is(ago(new Date(timestamp.valueOf() - (24 * 60 * 60 * 1000)), 'day', shortUnits), '1d ago');
+    t.is(ago(new Date(timestamp.valueOf() - (45 * 24 * 60 * 60 * 1000)), 'day', shortUnits), '45d ago');
+  }
+
+  // future
+  {
+    t.is(ago(new Date(timestamp.valueOf() + (70 * 1000)), 'day', shortUnits), 'in 1m');
+    t.is(ago(new Date(timestamp.valueOf() + (1.8 * 60 * 1000)), 'day', shortUnits), 'in 2m');
+    t.is(ago(new Date(timestamp.valueOf() + (14.7 * 60 * 1000)), 'day', shortUnits), 'in 15m');
+    t.is(ago(new Date(timestamp.valueOf() + (1.8 * 60 * 60 * 1000)), 'day', shortUnits), 'in 2h');
+    t.is(ago(new Date(timestamp.valueOf() + (18.8 * 60 * 60 * 1000)), 'day', shortUnits), 'in 19h');
+    t.is(ago(new Date(timestamp.valueOf() + (24 * 60 * 60 * 1000)), 'day', shortUnits), 'in 1d');
+    t.is(ago(new Date(timestamp.valueOf() + (45 * 24 * 60 * 60 * 1000)), 'day', shortUnits), 'in 45d');
+  }
+});


### PR DESCRIPTION
- Adds a new field to the objects in the `units` array containing the formatted (with whitespace) plural of each unit
- Allows passing in a custom units object to override the default one